### PR TITLE
Video Posts

### DIFF
--- a/src/Post.css
+++ b/src/Post.css
@@ -8,6 +8,19 @@
   object-position: center;
 }
 
+.video-wrapper {
+  position: relative;
+  padding-top: 56.25%;
+}
+
+.video-wrapper iframe {
+  position: relative;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .post-content {
   padding: 5% 10%;
   text-align: left;

--- a/src/Post.js
+++ b/src/Post.js
@@ -4,9 +4,19 @@ import LikeButton from './LikeButton';
 const Post = (props) => {
   return (
     <div className="post-wrapper">
+      { props.media_type === 'image' ?
       <img 
-        src={props.url} alt={props.title} />
-      
+        src={props.url} alt={props.title} /> :
+      <div className="video-wrapper">
+        <iframe
+          title={props.title}
+          src={props.url}
+          frameborder="0"
+          scrolling="auto"
+        >
+        </iframe>
+      </div>
+      }   
       <div className="post-content">
         <LikeButton />
         <h2 className="post-title">{props.title}</h2>


### PR DESCRIPTION
Fix issue where videos render as broken images by rendering an `iframe` element when returned object's media type is not 'image'.